### PR TITLE
Implement and simplify Uid Manager operations. Fixes #69.

### DIFF
--- a/src/main/java/seedu/address/logic/UidManager.java
+++ b/src/main/java/seedu/address/logic/UidManager.java
@@ -11,21 +11,20 @@ import seedu.address.model.person.Uid;
  */
 public class UidManager {
     private Queue<Uid> records;
-    private Queue<Uid> deletedUids;
 
     /**
      * Constructs a {@code UidManager}.
      */
     public UidManager() {
         this.records = new PriorityQueue<>(Collections.reverseOrder());
-        this.deletedUids = new PriorityQueue<>();
     }
 
     /**
      * Adds a new Uid to the pool of Uids in use.
+     *
      * @param newEntry
      */
-    public void addUid(Uid newEntry) {
+    private void addUid(Uid newEntry) {
         this.records.add(newEntry);
     }
 
@@ -33,12 +32,11 @@ public class UidManager {
      * Produces a new Uid that is ensured to not be duplicated in the system.
      */
     public Uid produceUid() {
-        if (deletedUids.peek() != null) {
-            return this.deletedUids.poll();
-        }
+        Uid newUid = new Uid(1L);
         if (this.records.peek() != null) {
-            return new Uid(this.records.peek().getId() + 1L);
+            newUid = new Uid(this.records.peek().getId() + 1L);
         }
-        return new Uid(1L);
+        this.addUid(newUid);
+        return newUid;
     }
 }

--- a/src/test/java/seedu/address/logic/UidManagerTest.java
+++ b/src/test/java/seedu/address/logic/UidManagerTest.java
@@ -1,0 +1,25 @@
+package seedu.address.logic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.person.Uid;
+
+public class UidManagerTest {
+
+    @Test
+    public void execute_produceUid_success() {
+        UidManager manager = new UidManager();
+        ArrayList<Uid> arr = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            arr.add(manager.produceUid());
+        }
+        List<Uid> arr2 = arr.stream().distinct().collect(Collectors.toList());
+        assertEquals(arr.size(), arr2.size());
+    }
+}


### PR DESCRIPTION
Uid Manager produce uid will produce a garantueed unique uid. The other commands can utilise this method to create the uid without input from the user.