### PR TITLE
Fix bug about not saving failed visited status

### DIFF
--- a/src/main/java/seedu/address/model/person/DateSlot.java
+++ b/src/main/java/seedu/address/model/person/DateSlot.java
@@ -77,7 +77,9 @@ public class DateSlot {
         this.hasAssigned = isAssigned;
         this.isSuccessVisit = isSucessVisit;
         this.nurseUidNo = nurseUidNo;
-        checkDateTime();
+        if (hasVisited == false) {
+            checkDateTime();
+        }
     }
 
     private static LocalDateTime parseDateSlot(String dateSlot) {


### PR DESCRIPTION
The bug is caused by dateslot constructor, when it is called, it will checkDateTime and it will convert it into successVisit if date passed.

Fix: will checkDateTime only if hasVisited is false. 